### PR TITLE
move web-console out of the Test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,12 +37,11 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
 
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0'
-
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'rspec-rails', '~> 3.0'
   gem 'capybara'
 end
 
+# Access an IRB console on exception pages or by using <%= console %> in views
+gem 'web-console', '~> 2.0', group: :development


### PR DESCRIPTION
Leaving `bcrypt` commented out on the assumption that one of the requirements for completing this lab is recognizing that BCrypt is not loaded and must be.
